### PR TITLE
Dev

### DIFF
--- a/packages/EasyFlash-v4.0.0/inc/ef_cfg.h
+++ b/packages/EasyFlash-v4.0.0/inc/ef_cfg.h
@@ -92,7 +92,7 @@
 #define EF_START_ADDR             PKG_EASYFLASH_START_ADDR
 
 /* ENV area size. It's at least one empty sector for GC. So it's definition must more then or equal 2 flash sector size. */
-#define ENV_AREA_SIZE             (EF_ERASE_MIN_SIZE * 6) /* default is the double erase min size */
+#define ENV_AREA_SIZE             (EF_ERASE_MIN_SIZE * 12) /* default is the double erase min size */
 
 /* print debug information of flash */
 #ifdef PKG_EASYFLASH_DEBUG

--- a/packages/EasyFlash-v4.0.0/src/ef_cmd.c
+++ b/packages/EasyFlash-v4.0.0/src/ef_cmd.c
@@ -80,7 +80,7 @@ MSH_CMD_EXPORT(resetenv, Reset all envrionment variable to default.);
 
 
 #if 1
-#define MY_STRING_SIZE 4224
+#define MY_STRING_SIZE 10000
 char string[MY_STRING_SIZE] = {'@'};
 
 static void setbatchenv(uint8_t argc, char **argv)

--- a/project.uvoptx
+++ b/project.uvoptx
@@ -159,7 +159,7 @@
           <Type>0</Type>
           <LineNumber>124</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134327234</Address>
+          <Address>134327410</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
@@ -173,9 +173,9 @@
         <Bp>
           <Number>1</Number>
           <Type>0</Type>
-          <LineNumber>1450</LineNumber>
+          <LineNumber>1497</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134247632</Address>
+          <Address>134247930</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
@@ -184,23 +184,7 @@
           <BreakIfRCount>1</BreakIfRCount>
           <Filename>packages\EasyFlash-v4.0.0\src\ef_env.c</Filename>
           <ExecCommand></ExecCommand>
-          <Expression>\\rt_thread\packages/EasyFlash-v4.0.0/src/ef_env.c\1450</Expression>
-        </Bp>
-        <Bp>
-          <Number>2</Number>
-          <Type>0</Type>
-          <LineNumber>1097</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>134246058</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>packages\EasyFlash-v4.0.0\src\ef_env.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\rt_thread\packages/EasyFlash-v4.0.0/src/ef_env.c\1097</Expression>
+          <Expression>\\rt_thread\packages/EasyFlash-v4.0.0/src/ef_env.c\1497</Expression>
         </Bp>
       </Breakpoint>
       <Tracepoint>

--- a/project.uvoptx
+++ b/project.uvoptx
@@ -159,7 +159,7 @@
           <Type>0</Type>
           <LineNumber>124</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134326038</Address>
+          <Address>134327234</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
@@ -175,7 +175,7 @@
           <Type>0</Type>
           <LineNumber>1450</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134260478</Address>
+          <Address>134247632</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
@@ -185,6 +185,22 @@
           <Filename>packages\EasyFlash-v4.0.0\src\ef_env.c</Filename>
           <ExecCommand></ExecCommand>
           <Expression>\\rt_thread\packages/EasyFlash-v4.0.0/src/ef_env.c\1450</Expression>
+        </Bp>
+        <Bp>
+          <Number>2</Number>
+          <Type>0</Type>
+          <LineNumber>1097</LineNumber>
+          <EnabledFlag>1</EnabledFlag>
+          <Address>134246058</Address>
+          <ByteObject>0</ByteObject>
+          <HtxType>0</HtxType>
+          <ManyObjects>0</ManyObjects>
+          <SizeOfObject>0</SizeOfObject>
+          <BreakByAccess>0</BreakByAccess>
+          <BreakIfRCount>1</BreakIfRCount>
+          <Filename>packages\EasyFlash-v4.0.0\src\ef_env.c</Filename>
+          <ExecCommand></ExecCommand>
+          <Expression>\\rt_thread\packages/EasyFlash-v4.0.0/src/ef_env.c\1097</Expression>
         </Bp>
       </Breakpoint>
       <Tracepoint>


### PR DESCRIPTION
## 实现大变量写入操作，修复写入位置偏移，导致读取扇区、变量出错的BUG。
### BUG复现及修复
部分扇区中的ENV出错情况
![Image](https://user-images.githubusercontent.com/30559085/87309788-a6380980-c54f-11ea-9c5b-1675123d87e7.png)
调试找到sector.empty_env不正确的问题
![Image](https://user-images.githubusercontent.com/30559085/87309797-a801cd00-c54f-11ea-9ea3-a65a6e0b178e.png)
找到在SHELL中输入的生成变量命令中<变量大小>参量，大于内建的数组大小，导致越界：
![Image](https://user-images.githubusercontent.com/30559085/87309802-a89a6380-c54f-11ea-8104-b42c216db4f5.png)
修改后大小变量都正常
![image](https://user-images.githubusercontent.com/30559085/87310172-2eb6aa00-c550-11ea-97b5-a2755435b61b.png)

### 发现的问题

- [ ] 首扇区为empty时，无法直接写入大变量，报越界错误。
- [ ] 垃圾清理程序没有改写，无法使用。
